### PR TITLE
Start local server without https if no certificates are found

### DIFF
--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -1,16 +1,32 @@
 const runDevServer = require('@uidu/webpack-config/bin/dev.js');
 const fs = require('fs');
 
+let https = undefined;
+
+try {
+  const key = fs.readFileSync('../../uidu/config/certs/key.pem');
+  const cert = fs.readFileSync('../../uidu/config/certs/crt.pem');
+  https = {
+    key,
+    cert,
+  };
+} catch (err) {
+  console.log(
+    'Https is disabled, you should have a uidu certificate to run it with SSL',
+  );
+}
+
 runDevServer({
-  serverOptions: {
-    // for testing on your mobile, disable https
-    // and bind address to 0.0.0.0 using ifconfig 192.168.xxx.xxx:9000
-    // https: false,
-    https: {
-      key: fs.readFileSync('../../uidu/config/certs/key.pem'),
-      cert: fs.readFileSync('../../uidu/config/certs/crt.pem'),
-    },
-  },
+  ...(https
+    ? {
+        serverOptions: {
+          // for testing on your mobile, disable https
+          // and bind address to 0.0.0.0 using ifconfig 192.168.xxx.xxx:9000
+          // https: false,
+          https,
+        },
+      }
+    : {}),
   webpackOptions: {
     resolve: {
       alias: {


### PR DESCRIPTION
## Description

Webpack config depends on uidu certificates for running in ssl_mode. Added a try-catch to be able to start local server without uidu repo pulled locally.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
