### PR TITLE
New Collection datafield

### DIFF
--- a/.changeset/smart-bikes-appear.md
+++ b/.changeset/smart-bikes-appear.md
@@ -1,0 +1,5 @@
+---
+'@uidu/data-fields': minor
+---
+
+New Collection datafield added

--- a/packages/data/data-fields/src/fields/collection/form.tsx
+++ b/packages/data/data-fields/src/fields/collection/form.tsx
@@ -1,0 +1,140 @@
+import {
+  faFont,
+  faGripVertical,
+  faTimes,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import FieldText from '@uidu/field-text';
+import { Field } from '../../types';
+import React, { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
+import { useIntl } from 'react-intl';
+
+const reorder = (
+  list: Field[],
+  startIndex: number,
+  endIndex: number,
+): Field[] => {
+  const result = Array.from(list);
+  const [removed] = result.splice(startIndex, 1);
+  result.splice(endIndex, 0, removed);
+
+  return result;
+};
+
+export default function CollectionFormWithFields({
+  prefix = 'attributes',
+  fields = [],
+}: {
+  prefix?: string;
+  fields: Field[];
+}) {
+  const intl = useIntl();
+
+  const [currentFields, setCurrentFields] = useState<Field[]>(fields);
+
+  const onDragEnd = (result) => {
+    // dropped outside the list
+    if (!result.destination) {
+      return;
+    }
+
+    setCurrentFields((prevCurrentFields) =>
+      reorder(prevCurrentFields, result.source.index, result.destination.index),
+    );
+  };
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      <Droppable droppableId="droppable">
+        {(provided, snapshot) => (
+          <div
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...provided.droppableProps}
+            ref={provided.innerRef}
+            // style={getListStyle(snapshot.isDraggingOver)}
+          >
+            {currentFields.map((field, index) => (
+              <Draggable
+                key={field.id}
+                draggableId={`draggable-${field.id}`}
+                index={index}
+              >
+                {(provided, snapshot) => (
+                  <div
+                    className="card d-flex align-items-center flex-row mb-3"
+                    ref={provided.innerRef}
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...provided.draggableProps}
+                  >
+                    <div
+                      className="mx-2 p-3 d-flex"
+                      // eslint-disable-next-line react/jsx-props-no-spreading
+                      {...provided.dragHandleProps}
+                    >
+                      <FontAwesomeIcon icon={faGripVertical} />
+                    </div>
+                    <div className="flex-grow-1 d-flex align-items-center">
+                      <FieldText
+                        type="hidden"
+                        name={`${prefix}[fields][${index}][position]`}
+                        value={index}
+                      />
+                      <FieldText
+                        name={`${prefix}[fields][${index}][name]`}
+                        layout="elementOnly"
+                        placeholder={intl.formatMessage({
+                          defaultMessage: 'Insert field name',
+                        })}
+                        required
+                        value={field.name}
+                        className="border-0"
+                      />
+                    </div>
+                    <button
+                      tabIndex={-1}
+                      type="button"
+                      className="btn btn-sm btn-simple"
+                      onClick={() => {
+                        setCurrentFields((prevCurrentFields) => [
+                          ...prevCurrentFields.slice(0, index),
+                          ...prevCurrentFields.slice(index + 1),
+                        ]);
+                      }}
+                    >
+                      <FontAwesomeIcon icon={faTimes} />
+                    </button>
+                  </div>
+                )}
+              </Draggable>
+            ))}
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
+      <div className="my-3">
+        <button
+          type="button"
+          className="btn btn-light btn-sm btn-block"
+          onClick={() => {
+            setCurrentFields((prevCurrentFields) => [
+              ...prevCurrentFields,
+              {
+                accessor: 'string',
+                id: prevCurrentFields.length + 1,
+                kind: 'string',
+                name: <FormattedMessage defaultMessage="String" />,
+                icon: <FontAwesomeIcon icon={faFont} />,
+                color: '#E4BA3F',
+                // form: StringForm,
+              },
+            ]);
+          }}
+        >
+          {intl.formatMessage({ defaultMessage: 'Add field' })}
+        </button>
+      </div>
+    </DragDropContext>
+  );
+}

--- a/packages/data/data-fields/src/fields/collection/index.tsx
+++ b/packages/data/data-fields/src/fields/collection/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { faBars } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import loadable from '@loadable/component';
+import { Field } from '../../types';
+
+const CollectionFormWithFields = loadable(() => import('./form'));
+
+const Collection: Partial<Field> = {
+  kind: 'collection',
+  name: (
+    <FormattedMessage id="field.collection.name" defaultMessage="Collection" />
+  ),
+  icon: <FontAwesomeIcon icon={faBars} />,
+  description: (
+    <FormattedMessage
+      id="field.collection.options"
+      defaultMessage="A collection is a list of items with one or more fields."
+    />
+  ),
+  color: '#73BEC8',
+  mocks: {
+    value: 'foo',
+    options: [
+      { id: 'foo', name: 'foo' },
+      { id: 'bar', name: 'bar' },
+    ],
+  },
+  form: CollectionFormWithFields,
+};
+
+export default Collection;

--- a/packages/data/data-fields/src/fields/index.ts
+++ b/packages/data/data-fields/src/fields/index.ts
@@ -4,6 +4,7 @@ import appointmentField from './appointment';
 import attachmentsField from './attachments';
 import avatarField from './avatar';
 import checkboxField from './checkbox';
+import collectionField from './collection';
 import contactField from './contact';
 import countryField from './country';
 import coverField from './cover';
@@ -31,6 +32,7 @@ export { default as appointmentField } from './appointment';
 export { default as attachmentsField } from './attachments';
 export { default as avatarField } from './avatar';
 export { default as checkboxField } from './checkbox';
+export { default as collectionField } from './collection';
 export { default as contactField } from './contact';
 export { default as countryField } from './country';
 export { default as coverField } from './cover';
@@ -59,6 +61,7 @@ export const byName = {
   attachments: attachmentsField,
   avatar: avatarField,
   checkbox: checkboxField,
+  collection: collectionField,
   contact: contactField,
   country: countryField,
   cover: coverField,
@@ -88,6 +91,7 @@ export default [
   attachmentsField,
   avatarField,
   checkboxField,
+  collectionField,
   contactField,
   countryField,
   coverField,

--- a/packages/data/data-fields/src/types.ts
+++ b/packages/data/data-fields/src/types.ts
@@ -7,6 +7,7 @@ export type FieldKind =
   | 'attachments'
   | 'avatar'
   | 'checkbox'
+  | 'collection'
   | 'contact'
   | 'country'
   | 'cover'

--- a/packages/data/data-fields/src/utils/index.tsx
+++ b/packages/data/data-fields/src/utils/index.tsx
@@ -6,6 +6,7 @@ import {
   avatarField,
   byName,
   checkboxField,
+  collectionField,
   contactField,
   countryField,
   coverField,
@@ -41,6 +42,8 @@ const getColumnType = (kind: Field['kind']) => {
       return avatarField;
     case 'checkbox':
       return checkboxField;
+    case 'collection':
+      return collectionField;
     case 'contact':
       return contactField;
     case 'country':

--- a/yarn.lock
+++ b/yarn.lock
@@ -6373,10 +6373,10 @@ __metadata:
     "@loadable/component": ^5.15.0
     "@uidu/dashboard-manager": ^1.0.1
     "@uidu/dashlet-controls": ^1.0.1
-    "@uidu/data-fields": ^1.0.4
+    "@uidu/data-fields": ^1.0.5
     "@uidu/docs": ^0.4.2
     "@uidu/spinner": ^0.5.1
-    "@uidu/table": 1.0.4
+    "@uidu/table": 1.0.5
     "@uidu/tooltip": ^0.5.2
     d3-array: ^3.0.2
     lodash: ^4.17.21
@@ -6428,7 +6428,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@uidu/data-fields@^1.0.3, @uidu/data-fields@^1.0.4, @uidu/data-fields@workspace:packages/data/data-fields":
+"@uidu/data-fields@^1.0.3, @uidu/data-fields@^1.0.4, @uidu/data-fields@^1.0.5, @uidu/data-fields@workspace:packages/data/data-fields":
   version: 0.0.0-use.local
   resolution: "@uidu/data-fields@workspace:packages/data/data-fields"
   dependencies:
@@ -8720,7 +8720,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@uidu/table@1.0.4, @uidu/table@^1.0.3, @uidu/table@workspace:packages/data/table":
+"@uidu/table@1.0.5, @uidu/table@^1.0.3, @uidu/table@workspace:packages/data/table":
   version: 0.0.0-use.local
   resolution: "@uidu/table@workspace:packages/data/table"
   dependencies:
@@ -8732,7 +8732,7 @@ __metadata:
     "@uidu/button": 1.2.1
     "@uidu/checkbox": ^1.1.2
     "@uidu/data-controls": ^1.0.3
-    "@uidu/data-fields": ^1.0.4
+    "@uidu/data-fields": ^1.0.5
     "@uidu/docs": ^0.4.2
     "@uidu/dropdown-menu": ^0.6.2
     "@uidu/menu": ^0.5.2


### PR DESCRIPTION
Created a new `Collection` data-field type.

## Description

A Collection data-field is a list of sortable objects.
Each object can contain one or more sortable data-fields.

## Motivation and Context

A Collection is needed to extend CMS functionality and to give the user the possibility to add a iterable set of objects to loop through. These objects can contain its own fields schema (just like a cms block), to store any kind of content structure.

## How Has This Been Tested?

It has not been tested yet, we just need the Collection basic data-field definition for the moment in order to receive in the FIELD_KINDS list.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
